### PR TITLE
Remove special handling for Vim 5.0

### DIFF
--- a/syntax/lua.vim
+++ b/syntax/lua.vim
@@ -8,11 +8,8 @@
 "				or 1, 2, 3 (for 5.1, 5.2 or 5.3)
 "		the default is 5.3
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
   finish
 endif
 
@@ -411,40 +408,30 @@ elseif lua_version == 5
 endif
 
 " Define the default highlighting.
-" For version 5.7 and earlier: only when not done already
-" For version 5.8 and later: only when an item doesn't have highlighting yet
-if version >= 508 || !exists("did_lua_syntax_inits")
-  if version < 508
-    let did_lua_syntax_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
+" Only when an item doesn't have highlighting yet
 
-  HiLink luaStatement		Statement
-  HiLink luaRepeat		Repeat
-  HiLink luaFor			Repeat
-  HiLink luaString		String
-  HiLink luaString2		String
-  HiLink luaNumber		Number
-  HiLink luaOperator		Operator
-  HiLink luaSymbolOperator	luaOperator
-  HiLink luaConstant		Constant
-  HiLink luaCond		Conditional
-  HiLink luaCondElse		Conditional
-  HiLink luaFunction		Function
-  HiLink luaMetaMethod		Function
-  HiLink luaComment		Comment
-  HiLink luaTodo		Todo
-  HiLink luaTable		Structure
-  HiLink luaError		Error
-  HiLink luaParenError		Error
-  HiLink luaSpecial		SpecialChar
-  HiLink luaFunc		Identifier
-  HiLink luaLabel		Label
+hi def link luaStatement	Statement
+hi def link luaRepeat		Repeat
+hi def link luaFor		Repeat
+hi def link luaString		String
+hi def link luaString2		String
+hi def link luaNumber		Number
+hi def link luaOperator		Operator
+hi def link luaSymbolOperator	luaOperator
+hi def link luaConstant		Constant
+hi def link luaCond		Conditional
+hi def link luaCondElse		Conditional
+hi def link luaFunction		Function
+hi def link luaMetaMethod	Function
+hi def link luaComment		Comment
+hi def link luaTodo		Todo
+hi def link luaTable		Structure
+hi def link luaError		Error
+hi def link luaParenError	Error
+hi def link luaSpecial		SpecialChar
+hi def link luaFunc		Identifier
+hi def link luaLabel		Label
 
-  delcommand HiLink
-endif
 
 let b:current_syntax = "lua"
 


### PR DESCRIPTION
Vim 6 is over twenty years old and the version 5 handling was removed
from all distributed syntax files in 2016.
